### PR TITLE
fix: correct asset paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Pawsh Pet Grooming Salon Website</title>
-    <script type="module" crossorigin src="/MasterEat-Pawsh-backup/assets/index-UHRmB_Gc.js"></script>
-    <link rel="stylesheet" crossorigin href="/MasterEat-Pawsh-backup/assets/index-Ta6gQHbb.css">
+    <script type="module" crossorigin src="./assets/index-UHRmB_Gc.js"></script>
+    <link rel="stylesheet" crossorigin href="./assets/index-Ta6gQHbb.css">
   </head>
   <body>
     <div id="root"></div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
-  base: '/',
+  base: '/Pawsh-backup/',
   plugins: [react()],
 })
 


### PR DESCRIPTION
## Summary
- use relative asset paths in `index.html`
- set Vite base to `/Pawsh-backup/`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: assets/index-UHRmB_Gc.js Unexpected eof)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e3d315588320b218dcd7f37b5f69